### PR TITLE
Fix Binder/conda cfg 

### DIFF
--- a/.binder/ReadMe.md
+++ b/.binder/ReadMe.md
@@ -3,4 +3,6 @@ Some configuration items for running things in this repo in Binder Project site 
 
 The configuration gets the Binder environment set with the .NET Interactive Jupyter kernel
 
-These are completely based on the Binder config files from [Dariel Dato-on](https://github.com/oddrationale) at https://github.com/oddrationale/AdventOfCode2020CSharp
+These are based on the Binder config files from [Dariel Dato-on](https://github.com/oddrationale) at https://github.com/oddrationale/AdventOfCode2020CSharp
+
+See Binder docs at for Configuration Files at https://mybinder.readthedocs.io/en/latest/using/config_files.html

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,7 +1,8 @@
-name: dotnet5.0
+name: latest_dotnet
 channels:
   - conda-forge
   - defaults
 dependencies:
-  - dotnet=5.0
-  
+  # - dotnet=5.0
+  ## use latest
+  - dotnet

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -3,6 +3,8 @@ set -ex
 
 export DOTNET_ROOT="/srv/conda/envs/notebook/lib/dotnet"
 export PATH=$PATH:$DOTNET_ROOT:~/.dotnet/tools
-dotnet tool install -g Microsoft.dotnet-interactive \
-    --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+## previous:  use dev source
+# dotnet tool install -g Microsoft.dotnet-interactive \
+    # --add-source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json"
+dotnet tool install --global Microsoft.dotnet-interactive
 dotnet interactive jupyter install


### PR DESCRIPTION
Fix Binder/conda configuration so that launching Jupyter things on mybinder.org from  to use modern versions of dotnet and interactive pkg (remove pinning and dev pkg source)